### PR TITLE
chore(deploy): reconcile compose/deploy.sh with the digest-pin model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 CLOUDFLARE_TUNNEL_TOKEN=your-token-here
 DISCORD_WEBHOOK_URL=your-discord-webhook-url-here
+
+# Optional: pin the exact web image to run (a tag or, preferred, a full digest ref).
+# Overrides the default pinned in docker-compose.yml. `deploy.sh` prints the running digest.
+# WEB_IMAGE=ghcr.io/airlangga07/mikaelairlangga-site@sha256:<digest>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,14 @@ Spins up containers, curls endpoints, asserts responses, tears down.
 
 ## Deploying (on the Pi)
 The site is baked into a **private GHCR image by CI** — it is not `git pull`ed onto the host.
-On `rpi3` the running image is **pinned by digest** in `docker-compose.yml`; deploy by updating
-the digest (or a semver tag) deliberately, then:
+On `rpi3` the running image is **pinned by digest** (via `WEB_IMAGE` in `.env`, or the default
+in `docker-compose.yml`); deploy a specific build with the helper — it sets `WEB_IMAGE`, pulls,
+recreates, and prints the running digest to pin:
 ```sh
 cd ~/apps/mikaelairlangga-site
-docker compose pull web
-docker compose up -d web        # verify, then:
+./deploy.sh v1.1.0     # a semver tag, or a full ...@sha256:<digest> ref (digest preferred)
+# equivalently, by hand:
+docker compose pull web && docker compose up -d web   # verify, then:
 docker compose up -d cloudflared
 ```
 Host / SSH / infra details live in the **Obsidian vault** → Infrastructure & Services →

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -77,18 +77,20 @@ mikaelairlangga-site/
 ## Deployment (on the Pi)
 
 The site ships as a **GHCR image**, not source — CI builds it on push to `main` (`sha-<shortsha>`)
-and on `vX.Y.Z` tags. On `rpi3` the running image is **pinned by digest** in the host's
-`docker-compose.yml`; deploy by bumping the digest (or a semver tag) deliberately:
+and on `vX.Y.Z` tags. On `rpi3` the running image is **pinned by digest** — via `WEB_IMAGE` in
+`.env` or the default in `docker-compose.yml`. Deploy a specific build with `deploy.sh`, which
+sets `WEB_IMAGE`, pulls, recreates, and prints the running digest so you can pin it:
 
 ```sh
 cd ~/apps/mikaelairlangga-site
-docker compose pull web
-docker compose up -d web        # verify, then:
-docker compose up -d cloudflared
+./deploy.sh v1.1.0     # a semver tag, or a full ...@sha256:<digest> ref (digest preferred)
+# by hand: docker compose pull web && docker compose up -d web && docker compose up -d cloudflared
 ```
 
-First-time setup only needs `.env` (from `.env.example`) with `CLOUDFLARE_TUNNEL_TOKEN` and
-`DISCORD_WEBHOOK_URL`, plus GHCR pull auth in `~/.docker/config.json`.
+Pinning by **digest** (not a moving tag) keeps prod immutable; bump the pinned default in
+`docker-compose.yml` (or set `WEB_IMAGE`) deliberately per release. First-time setup only needs
+`.env` (from `.env.example`) with `CLOUDFLARE_TUNNEL_TOKEN` and `DISCORD_WEBHOOK_URL`, plus GHCR
+pull auth in `~/.docker/config.json`.
 
 ## Verification
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,13 +4,26 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-TAG="${1:-latest}"
+IMAGE_BASE="ghcr.io/airlangga07/mikaelairlangga-site"
 
-echo "==> Deploying ghcr.io/airlangga07/mikaelairlangga-site:${TAG}"
+# With no args, deploys the digest pinned in docker-compose.yml (or WEB_IMAGE from .env).
+# Pass a semver tag or a full ref to deploy that instead — pinning by digest is preferred:
+#   ./deploy.sh v1.1.0
+#   ./deploy.sh ghcr.io/airlangga07/mikaelairlangga-site@sha256:<digest>
+REF="${1:-}"
+if [ -n "$REF" ]; then
+  case "$REF" in
+    *@sha256:* | */*) export WEB_IMAGE="$REF" ;;      # full ref or digest
+    *)                export WEB_IMAGE="${IMAGE_BASE}:${REF}" ;;  # bare tag
+  esac
+fi
 
-export WEB_TAG="$TAG"
+echo "==> Deploying ${WEB_IMAGE:-<digest pinned in docker-compose.yml>}"
 docker compose pull web
 docker compose up -d --remove-orphans
+
+echo "==> Running image digest (pin this in docker-compose.yml or WEB_IMAGE for immutability):"
+docker compose images web
 
 echo "==> Deploy complete."
 docker compose ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   web:
-    image: ghcr.io/airlangga07/mikaelairlangga-site:${WEB_TAG:-latest}
+    # Prod runs an immutable, digest-pinned image. Override per-deploy with WEB_IMAGE in
+    # .env (a tag or a full digest ref); bump the default below when cutting a release.
+    # `deploy.sh` prints the running digest so you can pin it. See PROJECT_SPEC.md.
+    image: ${WEB_IMAGE:-ghcr.io/airlangga07/mikaelairlangga-site@sha256:4ad5aa762f0e13d9490d36fc77d39280d3c94a18a757421f6ba037818474ec86}
     restart: unless-stopped
     ports:
       - "3001:3000"


### PR DESCRIPTION
Tidies the tag-vs-digest deploy drift flagged during the v1.1.0 ship.

**Problem:** the repo implied a moving tag (`docker-compose.yml` used `WEB_TAG:-latest`, `deploy.sh` defaulted to `:latest`), but prod on rpi3 pins the image **by digest**. A future `./deploy.sh` would have deployed `latest`, not the pinned build.

**Fix:**
- `docker-compose.yml` — default `web` to the current **v1.1.0 digest**, overridable via `WEB_IMAGE` (tag or full digest ref)
- `deploy.sh` — takes a tag/digest arg, sets `WEB_IMAGE`, prints the running digest to pin; no implicit `latest`
- `.env.example` — documents the optional `WEB_IMAGE` pin
- `CLAUDE.md` / `PROJECT_SPEC.md` — describe the `deploy.sh <ref>` / `WEB_IMAGE` flow

Repo and prod now tell the same digest-pinned story. `tests/test.sh` → 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)