### PR TITLE
chore(deploy): persist resolved digest to .env as WEB_IMAGE

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -18,12 +18,26 @@ if [ -n "$REF" ]; then
   esac
 fi
 
-echo "==> Deploying ${WEB_IMAGE:-<digest pinned in docker-compose.yml>}"
+echo "==> Deploying ${WEB_IMAGE:-<WEB_IMAGE from .env / default in docker-compose.yml>}"
 docker compose pull web
 docker compose up -d --remove-orphans
 
-echo "==> Running image digest (pin this in docker-compose.yml or WEB_IMAGE for immutability):"
-docker compose images web
+# Resolve the running image to an immutable digest and persist it as the .env pin, so a
+# later plain `docker compose up -d` (or a reboot) stays on exactly this build rather than
+# reverting to a stale WEB_IMAGE or the compose default.
+ENV_FILE="$SCRIPT_DIR/.env"
+DIGEST_REF="$(docker inspect --format '{{index .RepoDigests 0}}' "$(docker compose images -q web)" 2>/dev/null || true)"
+if [ -n "$DIGEST_REF" ] && [ -f "$ENV_FILE" ]; then
+  if grep -q '^WEB_IMAGE=' "$ENV_FILE"; then
+    sed -i "s|^WEB_IMAGE=.*|WEB_IMAGE=${DIGEST_REF}|" "$ENV_FILE"
+  else
+    printf '\nWEB_IMAGE=%s\n' "$DIGEST_REF" >> "$ENV_FILE"
+  fi
+  echo "==> Pinned WEB_IMAGE=${DIGEST_REF} in .env"
+else
+  echo "==> Running image digest (pin this in .env as WEB_IMAGE for immutability):"
+  docker compose images web
+fi
 
 echo "==> Deploy complete."
 docker compose ps


### PR DESCRIPTION
Follow-up to #20 and the rpi3↔repo unification. Makes `.env`'s `WEB_IMAGE` the durable source of truth for the deployed build.

After `pull` + `up`, `deploy.sh` resolves the running web image to an immutable digest and writes it back to `.env` as `WEB_IMAGE`. Without this, a later manual `docker compose up -d` (or an edge case on reboot) could revert to a stale pin or the compose default.

`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)