### PR TITLE
docs: deploy.sh auto-pins the digest into .env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Spins up containers, curls endpoints, asserts responses, tears down.
 The site is baked into a **private GHCR image by CI** — it is not `git pull`ed onto the host.
 On `rpi3` the running image is **pinned by digest** (via `WEB_IMAGE` in `.env`, or the default
 in `docker-compose.yml`); deploy a specific build with the helper — it sets `WEB_IMAGE`, pulls,
-recreates, and prints the running digest to pin:
+recreates, and pins the resolved digest back into `.env`:
 ```sh
 cd ~/apps/mikaelairlangga-site
 ./deploy.sh v1.1.0     # a semver tag, or a full ...@sha256:<digest> ref (digest preferred)

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -79,7 +79,7 @@ mikaelairlangga-site/
 The site ships as a **GHCR image**, not source — CI builds it on push to `main` (`sha-<shortsha>`)
 and on `vX.Y.Z` tags. On `rpi3` the running image is **pinned by digest** — via `WEB_IMAGE` in
 `.env` or the default in `docker-compose.yml`. Deploy a specific build with `deploy.sh`, which
-sets `WEB_IMAGE`, pulls, recreates, and prints the running digest so you can pin it:
+sets `WEB_IMAGE`, pulls, recreates, and pins the resolved digest back into `.env`:
 
 ```sh
 cd ~/apps/mikaelairlangga-site


### PR DESCRIPTION
Wording follow-up to #21 — runbooks now say deploy.sh persists `WEB_IMAGE` into `.env` automatically (it previously said it just prints the digest to pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)